### PR TITLE
Fix Docs :book: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,27 @@ pip install -r python_requirements.txt
 ## Paper
 We made a paper describing the tool and our findings with it. It can be found in the `paper` folder.
 
+## Configuration
+You can configure the OptiFuzz in the `config.json` file. Here you can
+- Configure what C compiler you want to use.
+- Configure what optimization flags you would like to test on.
+- Configure what kind of type of inputs you would like to fuzz with. We have defined a selection of "fuzzing classes":
+  - `uniform`: Inputs are 64-bit uniformly random numbers.
+  - `equal`: Inputs are 64-bit uniformly random numbers, but equal.
+  - `max64`: One input is `INT64_MAX` while the other is uniformly random.
+  - `umax64`: One input is `UINT64_MAX` while the other is uniformly random.
+  - `zero`: One input is 0 while the other is uniformly random.
+  - `xlty`: Inputs are 64-bit uniformly random numbers, but the first input is smaller than the second.
+  - `yltx`: Inputs are 64-bit uniformly random numbers, but the second input is smaller than the first.
+  - `small`: Inputs are 8-bit uniformly random numbers.
+- Configure if you would like to run the fuzzing in "kernel mode" where context switching and many CPU optimizations are disabled. This will decrease the noise of your results, however, the outcome depends on your specific system.
+
 ## Documentation
 `make` targets have been added for the whole pipeline. To run the whole pipeline, do `make all pn={# of random programs to generate} md={max depth of the generated ASTs} in={# of inputs the programs should be fuzzed with}`. At the end you will have a generated pdf report visualizing the results, the code, the assembly and some analysis in `analysis/latex/master.pdf`.
 
 As an example `make all pn=1000 md=5 in=100000` will run the whole pipeline on 1000 random programs with ASTs of maximum depth 5 where each program is fuzzed with 100000 inputs.
+
+Note that `in` describes the number of inputs a given program will be fuzzed with for _each_ fuzzing class.
 
 For a full description of the `make` targets, see:
 ```


### PR DESCRIPTION
This PR cleans up and enhances the docs:
- The section about `make` targets is now up to date and improved.
- The section about dependencies is now better with links.
- A section about configuring the tool has been added.